### PR TITLE
Add W-22247030 file download timeout test pages

### DIFF
--- a/feature-testing/W-22247030-file-download-timeout/TC01-happy-path-small-file.html
+++ b/feature-testing/W-22247030-file-download-timeout/TC01-happy-path-small-file.html
@@ -1,0 +1,70 @@
+<html>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+  <title>TC01 - Happy Path Small File Download</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 20px; background: #1a1a2e; color: #eee; }
+    .test-card { background: #16213e; border-radius: 8px; padding: 24px; max-width: 700px; margin: 0 auto 20px; }
+    h1 { color: #0af; font-size: 1.4em; margin-top: 0; }
+    h2 { color: #4cc9f0; font-size: 1.1em; }
+    .badge { display: inline-block; padding: 3px 10px; border-radius: 12px; font-size: 0.8em; font-weight: 600; }
+    .manual { background: #f72585; }
+    .suite { background: #3a0ca3; }
+    ol { padding-left: 20px; }
+    li { margin-bottom: 8px; line-height: 1.5; }
+    .expected { background: #0d1b2a; border-left: 3px solid #0af; padding: 12px; margin-top: 12px; border-radius: 4px; }
+    code { background: #0d1b2a; padding: 2px 6px; border-radius: 3px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <div class="test-card">
+    <span class="badge suite">Functional Correctness</span>
+    <span class="badge manual">Manual</span>
+    <h1>TC01: Same-tab Download of a Small PDF Completes Under Normal Network</h1>
+    <h2>Pre-conditions</h2>
+    <ul>
+      <li>Bootstrap loaded with default settings (<code>shouldOpenFileInNewTab=false</code>)</li>
+      <li>Active live-agent session in MIAW Enhanced Messaging</li>
+      <li>Agent has just sent a small PDF (&lt;100KB)</li>
+    </ul>
+    <h2>Steps to Reproduce</h2>
+    <ol>
+      <li>Open this page and wait for the chat widget to appear (bottom-right).</li>
+      <li>Click the chat FAB to open the conversation.</li>
+      <li>Start a conversation with the agent. Ask it to send you a file.</li>
+      <li>When the agent sends a file attachment, click the <strong>download button</strong> on the attachment.</li>
+      <li>Wait for the browser to commit the download.</li>
+      <li>Inspect the OS download folder for the file.</li>
+      <li>Open the file and verify the content matches the source.</li>
+    </ol>
+    <div class="expected">
+      <h2>Expected Results</h2>
+      <ul>
+        <li>File downloads on first click without retry.</li>
+        <li>File name and content match the source byte-for-byte.</li>
+        <li>DevTools Network tab shows the iframe request reaches Status 200/finished &mdash; never <code>(canceled)</code>.</li>
+        <li>Console is free of errors and warnings.</li>
+      </ul>
+    </div>
+  </div>
+
+  <script type='text/javascript'>
+    function initEmbeddedMessaging() {
+      try {
+        embeddedservice_bootstrap.settings.language = 'en_US';
+        embeddedservice_bootstrap.init(
+          '00DSB00000da1NJ',
+          'CWC01_External',
+          'https://orgfarm-46c4c41fb0.test1.my.pc-rnd.site.com/ESWCWC01External1763517787129',
+          {
+            scrt2URL: 'https://orgfarm-46c4c41fb0.test1.my.pc-rnd.salesforce-scrt.com'
+          }
+        );
+      } catch (err) {
+        console.error('Error loading Embedded Messaging: ', err);
+      }
+    };
+  </script>
+  <script type='text/javascript' src='https://orgfarm-46c4c41fb0.test1.my.pc-rnd.site.com/ESWCWC01External1763517787129/assets/js/bootstrap.min.js' onload='initEmbeddedMessaging()'></script>
+</body>
+</html>

--- a/feature-testing/W-22247030-file-download-timeout/TC02-slow-network-large-file.html
+++ b/feature-testing/W-22247030-file-download-timeout/TC02-slow-network-large-file.html
@@ -1,0 +1,84 @@
+<html>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+  <title>TC02 - Slow Network Large File Download (Core Bug Repro)</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 20px; background: #1a1a2e; color: #eee; }
+    .test-card { background: #16213e; border-radius: 8px; padding: 24px; max-width: 700px; margin: 0 auto 20px; }
+    h1 { color: #0af; font-size: 1.4em; margin-top: 0; }
+    h2 { color: #4cc9f0; font-size: 1.1em; }
+    .badge { display: inline-block; padding: 3px 10px; border-radius: 12px; font-size: 0.8em; font-weight: 600; }
+    .manual { background: #f72585; }
+    .suite { background: #3a0ca3; }
+    .critical { background: #e63946; }
+    ol { padding-left: 20px; }
+    li { margin-bottom: 8px; line-height: 1.5; }
+    .expected { background: #0d1b2a; border-left: 3px solid #0af; padding: 12px; margin-top: 12px; border-radius: 4px; }
+    .warning { background: #2d1b00; border-left: 3px solid #f77f00; padding: 12px; margin-top: 12px; border-radius: 4px; }
+    code { background: #0d1b2a; padding: 2px 6px; border-radius: 3px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <div class="test-card">
+    <span class="badge suite">Slow-Network Resilience</span>
+    <span class="badge manual">Manual</span>
+    <span class="badge critical">Core Fix Area</span>
+    <h1>TC02: Slow 3G Download of a 5MB PDF Succeeds First Try (Customer Repro)</h1>
+    <div class="warning">
+      <strong>This is the core bug scenario from W-22247030.</strong> The original customer (Copyright Clearance Center) saw downloads abort at 862&ndash;950ms due to the 1000ms iframe cleanup timeout.
+    </div>
+    <h2>Pre-conditions</h2>
+    <ul>
+      <li>Chrome DevTools open (F12)</li>
+      <li>Network throttling set to <strong>Slow 3G</strong> (DevTools &rarr; Network &rarr; Throttling dropdown)</li>
+      <li>Active live-agent session with file transfer capability</li>
+      <li>Agent has a ~5MB PDF ready to send</li>
+    </ul>
+    <h2>Steps to Reproduce</h2>
+    <ol>
+      <li>Open Chrome DevTools (F12) and go to the <strong>Network</strong> tab.</li>
+      <li>Set throttling to <strong>Slow 3G</strong>.</li>
+      <li>Open this page and wait for the chat widget to appear.</li>
+      <li>Click the chat FAB to start a conversation.</li>
+      <li>Ask the agent to send a ~5MB file attachment.</li>
+      <li>When the file attachment appears, click the <strong>download button</strong>.</li>
+      <li>Observe the Network panel &mdash; watch for the iframe request timing.</li>
+      <li>Capture HAR if needed: right-click in Network panel &rarr; Save all as HAR.</li>
+    </ol>
+    <div class="expected">
+      <h2>Expected Results (Post-Fix)</h2>
+      <ul>
+        <li>Download completes on first click &mdash; no retry needed.</li>
+        <li>HAR shows the request reaching commit even if total time exceeds 1000ms.</li>
+        <li>No <code>net::ERR_ABORTED</code> in the Network panel.</li>
+        <li>File content matches source byte-for-byte.</li>
+      </ul>
+      <h2>Pre-Fix Behavior (Bug)</h2>
+      <ul>
+        <li>Download silently fails or stalls at ~862&ndash;950ms.</li>
+        <li>Network panel shows <code>(canceled)</code> on the iframe request.</li>
+        <li>Retrying sometimes succeeds (race condition with the 1000ms timeout).</li>
+      </ul>
+    </div>
+  </div>
+
+  <script type='text/javascript'>
+    function initEmbeddedMessaging() {
+      try {
+        embeddedservice_bootstrap.settings.language = 'en_US';
+        embeddedservice_bootstrap.init(
+          '00DSB00000da1NJ',
+          'CWC01_External',
+          'https://orgfarm-46c4c41fb0.test1.my.pc-rnd.site.com/ESWCWC01External1763517787129',
+          {
+            scrt2URL: 'https://orgfarm-46c4c41fb0.test1.my.pc-rnd.salesforce-scrt.com'
+          }
+        );
+      } catch (err) {
+        console.error('Error loading Embedded Messaging: ', err);
+      }
+    };
+  </script>
+  <script type='text/javascript' src='https://orgfarm-46c4c41fb0.test1.my.pc-rnd.site.com/ESWCWC01External1763517787129/assets/js/bootstrap.min.js' onload='initEmbeddedMessaging()'></script>
+</body>
+</html>

--- a/feature-testing/W-22247030-file-download-timeout/TC03-dom-hygiene-50-downloads.html
+++ b/feature-testing/W-22247030-file-download-timeout/TC03-dom-hygiene-50-downloads.html
@@ -1,0 +1,80 @@
+<html>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+  <title>TC03 - DOM Hygiene: 50 Sequential Downloads</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 20px; background: #1a1a2e; color: #eee; }
+    .test-card { background: #16213e; border-radius: 8px; padding: 24px; max-width: 700px; margin: 0 auto 20px; }
+    h1 { color: #0af; font-size: 1.4em; margin-top: 0; }
+    h2 { color: #4cc9f0; font-size: 1.1em; }
+    .badge { display: inline-block; padding: 3px 10px; border-radius: 12px; font-size: 0.8em; font-weight: 600; }
+    .manual { background: #f72585; }
+    .suite { background: #3a0ca3; }
+    ol { padding-left: 20px; }
+    li { margin-bottom: 8px; line-height: 1.5; }
+    .expected { background: #0d1b2a; border-left: 3px solid #0af; padding: 12px; margin-top: 12px; border-radius: 4px; }
+    code { background: #0d1b2a; padding: 2px 6px; border-radius: 3px; font-size: 0.9em; }
+    .console-snippet { background: #0d1b2a; padding: 12px; border-radius: 4px; margin: 8px 0; font-family: monospace; font-size: 0.85em; white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+  <div class="test-card">
+    <span class="badge suite">Iframe Lifecycle &amp; DOM Hygiene</span>
+    <span class="badge manual">Manual</span>
+    <h1>TC03: 50 Sequential Downloads Do Not Leak DOM Nodes</h1>
+    <h2>Pre-conditions</h2>
+    <ul>
+      <li>Active session with the agent</li>
+      <li>Agent able to send multiple small attachments (~100KB each)</li>
+      <li>DevTools Console open</li>
+    </ul>
+    <h2>Steps to Reproduce</h2>
+    <ol>
+      <li>Open this page and start a chat session.</li>
+      <li>Before any downloads, run this in the DevTools Console to record baseline iframe count:</li>
+    </ol>
+    <div class="console-snippet">// Record baseline
+console.log('Baseline iframes:', document.querySelectorAll('iframe').length);</div>
+    <ol start="3">
+      <li>Have the agent send a small file attachment.</li>
+      <li>Click download on the attachment. Wait for it to complete.</li>
+      <li>Repeat steps 3&ndash;4 at least 50 times (or as many as practical).</li>
+      <li>After all downloads complete, run this in the Console:</li>
+    </ol>
+    <div class="console-snippet">// Check for orphan iframes after downloads
+console.log('Final iframes:', document.querySelectorAll('iframe').length);
+console.log('Orphan download iframes:', document.querySelectorAll('iframe[style*="display: none"]').length);</div>
+    <ol start="7">
+      <li>Take a heap snapshot (DevTools &rarr; Memory &rarr; Take snapshot) and note the total size.</li>
+    </ol>
+    <div class="expected">
+      <h2>Expected Results</h2>
+      <ul>
+        <li>Final iframe count equals baseline (no orphan download iframes remain).</li>
+        <li>All files downloaded successfully.</li>
+        <li>Heap snapshot delta &lt; 5MB compared to baseline.</li>
+        <li>No <code>removeChild</code> errors in the Console.</li>
+      </ul>
+    </div>
+  </div>
+
+  <script type='text/javascript'>
+    function initEmbeddedMessaging() {
+      try {
+        embeddedservice_bootstrap.settings.language = 'en_US';
+        embeddedservice_bootstrap.init(
+          '00DSB00000da1NJ',
+          'CWC01_External',
+          'https://orgfarm-46c4c41fb0.test1.my.pc-rnd.site.com/ESWCWC01External1763517787129',
+          {
+            scrt2URL: 'https://orgfarm-46c4c41fb0.test1.my.pc-rnd.salesforce-scrt.com'
+          }
+        );
+      } catch (err) {
+        console.error('Error loading Embedded Messaging: ', err);
+      }
+    };
+  </script>
+  <script type='text/javascript' src='https://orgfarm-46c4c41fb0.test1.my.pc-rnd.site.com/ESWCWC01External1763517787129/assets/js/bootstrap.min.js' onload='initEmbeddedMessaging()'></script>
+</body>
+</html>

--- a/feature-testing/W-22247030-file-download-timeout/TC04-concurrent-downloads.html
+++ b/feature-testing/W-22247030-file-download-timeout/TC04-concurrent-downloads.html
@@ -1,0 +1,70 @@
+<html>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+  <title>TC04 - Back-to-Back Concurrent Downloads</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 20px; background: #1a1a2e; color: #eee; }
+    .test-card { background: #16213e; border-radius: 8px; padding: 24px; max-width: 700px; margin: 0 auto 20px; }
+    h1 { color: #0af; font-size: 1.4em; margin-top: 0; }
+    h2 { color: #4cc9f0; font-size: 1.1em; }
+    .badge { display: inline-block; padding: 3px 10px; border-radius: 12px; font-size: 0.8em; font-weight: 600; }
+    .manual { background: #f72585; }
+    .suite { background: #3a0ca3; }
+    ol { padding-left: 20px; }
+    li { margin-bottom: 8px; line-height: 1.5; }
+    .expected { background: #0d1b2a; border-left: 3px solid #0af; padding: 12px; margin-top: 12px; border-radius: 4px; }
+    code { background: #0d1b2a; padding: 2px 6px; border-radius: 3px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <div class="test-card">
+    <span class="badge suite">Functional Correctness</span>
+    <span class="badge manual">Manual</span>
+    <h1>TC04: Back-to-Back Download Clicks Do Not Abort Each Other</h1>
+    <h2>Pre-conditions</h2>
+    <ul>
+      <li>Active session with the agent</li>
+      <li>Agent has sent at least two file attachments (e.g. two 2MB PDFs)</li>
+      <li>DevTools Network tab open</li>
+    </ul>
+    <h2>Steps to Reproduce</h2>
+    <ol>
+      <li>Open this page and start a chat session.</li>
+      <li>Ask the agent to send two file attachments.</li>
+      <li>Once both attachments are visible in the chat, click download on the <strong>first file</strong>.</li>
+      <li>Within ~200ms (immediately after), click download on the <strong>second file</strong> before the first finishes.</li>
+      <li>Wait for both to commit.</li>
+      <li>Check the OS download folder for both files.</li>
+      <li>Check DevTools Network panel for any <code>(canceled)</code> requests.</li>
+    </ol>
+    <div class="expected">
+      <h2>Expected Results</h2>
+      <ul>
+        <li>Both files arrive in the OS download folder.</li>
+        <li>Neither request shows as <code>(canceled)</code> in DevTools Network.</li>
+        <li>No DOM iframe leak after both complete (check with <code>document.querySelectorAll('iframe').length</code>).</li>
+        <li>No console errors.</li>
+      </ul>
+    </div>
+  </div>
+
+  <script type='text/javascript'>
+    function initEmbeddedMessaging() {
+      try {
+        embeddedservice_bootstrap.settings.language = 'en_US';
+        embeddedservice_bootstrap.init(
+          '00DSB00000da1NJ',
+          'CWC01_External',
+          'https://orgfarm-46c4c41fb0.test1.my.pc-rnd.site.com/ESWCWC01External1763517787129',
+          {
+            scrt2URL: 'https://orgfarm-46c4c41fb0.test1.my.pc-rnd.salesforce-scrt.com'
+          }
+        );
+      } catch (err) {
+        console.error('Error loading Embedded Messaging: ', err);
+      }
+    };
+  </script>
+  <script type='text/javascript' src='https://orgfarm-46c4c41fb0.test1.my.pc-rnd.site.com/ESWCWC01External1763517787129/assets/js/bootstrap.min.js' onload='initEmbeddedMessaging()'></script>
+</body>
+</html>

--- a/feature-testing/W-22247030-file-download-timeout/TC05-network-drop-mid-download.html
+++ b/feature-testing/W-22247030-file-download-timeout/TC05-network-drop-mid-download.html
@@ -1,0 +1,72 @@
+<html>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+  <title>TC05 - Network Drop Mid-Download</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 20px; background: #1a1a2e; color: #eee; }
+    .test-card { background: #16213e; border-radius: 8px; padding: 24px; max-width: 700px; margin: 0 auto 20px; }
+    h1 { color: #0af; font-size: 1.4em; margin-top: 0; }
+    h2 { color: #4cc9f0; font-size: 1.1em; }
+    .badge { display: inline-block; padding: 3px 10px; border-radius: 12px; font-size: 0.8em; font-weight: 600; }
+    .manual { background: #f72585; }
+    .suite { background: #3a0ca3; }
+    ol { padding-left: 20px; }
+    li { margin-bottom: 8px; line-height: 1.5; }
+    .expected { background: #0d1b2a; border-left: 3px solid #0af; padding: 12px; margin-top: 12px; border-radius: 4px; }
+    code { background: #0d1b2a; padding: 2px 6px; border-radius: 3px; font-size: 0.9em; }
+  </style>
+</head>
+<body>
+  <div class="test-card">
+    <span class="badge suite">Error Handling &amp; Recoverability</span>
+    <span class="badge manual">Manual</span>
+    <h1>TC05: Network Drops Mid-Download</h1>
+    <h2>Pre-conditions</h2>
+    <ul>
+      <li>Active session with the agent</li>
+      <li>A large file (~10MB+) ready to be sent by agent (to keep download in-flight long enough)</li>
+      <li>DevTools open with Network tab and Console visible</li>
+    </ul>
+    <h2>Steps to Reproduce</h2>
+    <ol>
+      <li>Open this page and start a chat session.</li>
+      <li>Ask the agent to send a large file attachment (~10MB).</li>
+      <li>Click the download button on the attachment.</li>
+      <li>While the download is <strong>in-flight</strong> (visible in Network panel as pending), toggle the browser to <strong>Offline</strong> mode:
+        <br>DevTools &rarr; Network &rarr; check "Offline" checkbox.</li>
+      <li>Observe the Console for errors.</li>
+      <li>Toggle back <strong>Online</strong> (uncheck "Offline").</li>
+      <li>Click the download button again to retry.</li>
+    </ol>
+    <div class="expected">
+      <h2>Expected Results</h2>
+      <ul>
+        <li>First attempt surfaces a clear failure (event/log in console) &mdash; NOT a silent abort.</li>
+        <li>The iframe is still cleaned up (no orphan iframe after failure).</li>
+        <li>Retry after reconnect succeeds &mdash; file downloads completely.</li>
+        <li>No uncaught exceptions that break subsequent downloads.</li>
+        <li>No <code>removeChild</code>-on-detached-node error in console.</li>
+      </ul>
+    </div>
+  </div>
+
+  <script type='text/javascript'>
+    function initEmbeddedMessaging() {
+      try {
+        embeddedservice_bootstrap.settings.language = 'en_US';
+        embeddedservice_bootstrap.init(
+          '00DSB00000da1NJ',
+          'CWC01_External',
+          'https://orgfarm-46c4c41fb0.test1.my.pc-rnd.site.com/ESWCWC01External1763517787129',
+          {
+            scrt2URL: 'https://orgfarm-46c4c41fb0.test1.my.pc-rnd.salesforce-scrt.com'
+          }
+        );
+      } catch (err) {
+        console.error('Error loading Embedded Messaging: ', err);
+      }
+    };
+  </script>
+  <script type='text/javascript' src='https://orgfarm-46c4c41fb0.test1.my.pc-rnd.site.com/ESWCWC01External1763517787129/assets/js/bootstrap.min.js' onload='initEmbeddedMessaging()'></script>
+</body>
+</html>

--- a/feature-testing/W-22247030-file-download-timeout/TC06-accessibility-hidden-iframe.html
+++ b/feature-testing/W-22247030-file-download-timeout/TC06-accessibility-hidden-iframe.html
@@ -1,0 +1,79 @@
+<html>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+  <title>TC06 - Accessibility: Hidden Iframe Not in Focus Order</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 20px; background: #1a1a2e; color: #eee; }
+    .test-card { background: #16213e; border-radius: 8px; padding: 24px; max-width: 700px; margin: 0 auto 20px; }
+    h1 { color: #0af; font-size: 1.4em; margin-top: 0; }
+    h2 { color: #4cc9f0; font-size: 1.1em; }
+    .badge { display: inline-block; padding: 3px 10px; border-radius: 12px; font-size: 0.8em; font-weight: 600; }
+    .manual { background: #f72585; }
+    .suite { background: #3a0ca3; }
+    ol { padding-left: 20px; }
+    li { margin-bottom: 8px; line-height: 1.5; }
+    .expected { background: #0d1b2a; border-left: 3px solid #0af; padding: 12px; margin-top: 12px; border-radius: 4px; }
+    code { background: #0d1b2a; padding: 2px 6px; border-radius: 3px; font-size: 0.9em; }
+    .console-snippet { background: #0d1b2a; padding: 12px; border-radius: 4px; margin: 8px 0; font-family: monospace; font-size: 0.85em; white-space: pre-wrap; }
+  </style>
+</head>
+<body>
+  <div class="test-card">
+    <span class="badge suite">Accessibility Regression</span>
+    <span class="badge manual">Manual</span>
+    <h1>TC06: Hidden Download Iframe Stays Out of Focus Order and A11y Tree</h1>
+    <h2>Pre-conditions</h2>
+    <ul>
+      <li>Active session with the agent</li>
+      <li>Chrome DevTools open (Elements panel + Accessibility panel)</li>
+      <li>Optional: VoiceOver (macOS) or NVDA (Windows) running</li>
+    </ul>
+    <h2>Steps to Reproduce</h2>
+    <ol>
+      <li>Open this page and start a chat session.</li>
+      <li>Ask the agent to send a file attachment.</li>
+      <li>Open Chrome DevTools &rarr; Elements &rarr; Accessibility panel (sidebar).</li>
+      <li>Click the download button on the attachment.</li>
+      <li>While the download is in-flight, inspect the accessibility tree for any new iframe elements:</li>
+    </ol>
+    <div class="console-snippet">// Check a11y tree for hidden iframes
+document.querySelectorAll('iframe[style*="display: none"]').forEach(el => {
+  console.log('Hidden iframe:', el.title, '| tabIndex:', el.tabIndex, '| aria-hidden:', el.getAttribute('aria-hidden'));
+});</div>
+    <ol start="6">
+      <li>Try pressing <strong>Tab</strong> repeatedly through the page. Check if focus ever lands on the hidden iframe.</li>
+      <li>If using a screen reader, listen for any announcement of a new iframe during the download.</li>
+      <li>Trigger 5 downloads in a row and listen for SR announcements each time.</li>
+    </ol>
+    <div class="expected">
+      <h2>Expected Results</h2>
+      <ul>
+        <li>Iframe has <code>style="display: none"</code> &mdash; does not appear in the a11y tree.</li>
+        <li>Tab key never focuses the hidden download iframe.</li>
+        <li>Screen reader does not announce a new element on each download.</li>
+        <li>The iframe <code>title</code> attribute is present (e.g. "File Download") for cases where it might become visible.</li>
+        <li>Existing SR announcements for the messaging surface are unchanged.</li>
+      </ul>
+    </div>
+  </div>
+
+  <script type='text/javascript'>
+    function initEmbeddedMessaging() {
+      try {
+        embeddedservice_bootstrap.settings.language = 'en_US';
+        embeddedservice_bootstrap.init(
+          '00DSB00000da1NJ',
+          'CWC01_External',
+          'https://orgfarm-46c4c41fb0.test1.my.pc-rnd.site.com/ESWCWC01External1763517787129',
+          {
+            scrt2URL: 'https://orgfarm-46c4c41fb0.test1.my.pc-rnd.salesforce-scrt.com'
+          }
+        );
+      } catch (err) {
+        console.error('Error loading Embedded Messaging: ', err);
+      }
+    };
+  </script>
+  <script type='text/javascript' src='https://orgfarm-46c4c41fb0.test1.my.pc-rnd.site.com/ESWCWC01External1763517787129/assets/js/bootstrap.min.js' onload='initEmbeddedMessaging()'></script>
+</body>
+</html>

--- a/feature-testing/W-22247030-file-download-timeout/index.html
+++ b/feature-testing/W-22247030-file-download-timeout/index.html
@@ -1,0 +1,95 @@
+<html>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1">
+  <title>W-22247030 - File Download Iframe Cleanup Timeout - Test Cases</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 20px; background: #1a1a2e; color: #eee; }
+    .container { max-width: 800px; margin: 0 auto; }
+    h1 { color: #0af; }
+    h2 { color: #4cc9f0; margin-top: 30px; }
+    .description { background: #16213e; border-radius: 8px; padding: 16px; margin-bottom: 20px; line-height: 1.6; }
+    table { width: 100%; border-collapse: collapse; margin-top: 12px; }
+    th { background: #0d1b2a; text-align: left; padding: 10px 12px; font-size: 0.9em; color: #4cc9f0; }
+    td { padding: 10px 12px; border-bottom: 1px solid #16213e; }
+    a { color: #0af; text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    .badge { display: inline-block; padding: 2px 8px; border-radius: 10px; font-size: 0.75em; font-weight: 600; }
+    .critical { background: #e63946; }
+    .high { background: #f77f00; }
+    .medium { background: #3a0ca3; }
+    .info { background: #16213e; border: 1px solid #4cc9f0; }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <h1>W-22247030: File Downloads Aborted by 1000ms Iframe Cleanup Timeout</h1>
+    <div class="description">
+      <strong>Bug Summary:</strong> When an end user clicks the download button on an agent-sent file in Enhanced Messaging, the bootstrap layer creates a hidden iframe and unconditionally removes it after 1000ms. If the response hasn't committed by then, the download silently fails with <code>net::ERR_ABORTED</code>.
+      <br><br>
+      <strong>Org:</strong> SDB3 (OrgFarm) &mdash; <code>00DSB00000da1NJ</code><br>
+      <strong>Deployment:</strong> CWC01_External &mdash; MessagingChannel01 &mdash; Food Service Agent1<br>
+      <strong>Agent Login:</strong> agent1@cwc.org / test1234<br>
+      <strong>Sprint:</strong> 2026.05b-ESW
+    </div>
+
+    <h2>Test Cases</h2>
+    <table>
+      <tr>
+        <th>ID</th>
+        <th>Test Case</th>
+        <th>Suite</th>
+        <th>Priority</th>
+      </tr>
+      <tr>
+        <td>TC01</td>
+        <td><a href="TC01-happy-path-small-file.html">Same-tab download of a small PDF completes</a></td>
+        <td>Functional Correctness</td>
+        <td><span class="badge high">High</span></td>
+      </tr>
+      <tr>
+        <td>TC02</td>
+        <td><a href="TC02-slow-network-large-file.html">Slow 3G download of 5MB PDF succeeds first try (customer repro)</a></td>
+        <td>Slow-Network Resilience</td>
+        <td><span class="badge critical">Critical</span></td>
+      </tr>
+      <tr>
+        <td>TC03</td>
+        <td><a href="TC03-dom-hygiene-50-downloads.html">50 sequential downloads do not leak DOM nodes</a></td>
+        <td>Iframe Lifecycle &amp; DOM Hygiene</td>
+        <td><span class="badge high">High</span></td>
+      </tr>
+      <tr>
+        <td>TC04</td>
+        <td><a href="TC04-concurrent-downloads.html">Back-to-back download clicks do not abort each other</a></td>
+        <td>Functional Correctness</td>
+        <td><span class="badge high">High</span></td>
+      </tr>
+      <tr>
+        <td>TC05</td>
+        <td><a href="TC05-network-drop-mid-download.html">Network drops mid-download: observable failure, retry works</a></td>
+        <td>Error Handling</td>
+        <td><span class="badge medium">Medium</span></td>
+      </tr>
+      <tr>
+        <td>TC06</td>
+        <td><a href="TC06-accessibility-hidden-iframe.html">Hidden iframe stays out of focus order &amp; a11y tree</a></td>
+        <td>Accessibility Regression</td>
+        <td><span class="badge medium">Medium</span></td>
+      </tr>
+    </table>
+
+    <h2>How to Test</h2>
+    <div class="description">
+      <ol>
+        <li>Click a test case link above to open the test page with the embedded chat widget.</li>
+        <li>Follow the steps listed on the page.</li>
+        <li>To send files AS the agent, log into the org's Service Console:<br>
+          <code>https://orgfarm-46c4c41fb0.test1.lightning.pc-rnd.force.com</code><br>
+          Agent: <code>agent1@cwc.org</code> / <code>test1234</code><br>
+          Open Omni-Channel, set status to Available, and accept the incoming messaging session.</li>
+        <li>From the agent console, use the attachment button to send files to the end user.</li>
+      </ol>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds `feature-testing/W-22247030-file-download-timeout/` directory with 6 test case pages + index
- Each page embeds the CWC01_External chat widget and lists step-by-step reproduction instructions
- Covers: happy path download, slow network (core bug repro), DOM hygiene, concurrent downloads, network failure recovery, and accessibility

## Test Cases
| ID | Scenario | Priority |
|----|----------|----------|
| TC01 | Same-tab download of small PDF | High |
| TC02 | Slow 3G download of 5MB PDF (customer repro) | Critical |
| TC03 | 50 sequential downloads - no DOM leak | High |
| TC04 | Concurrent downloads don't abort each other | High |
| TC05 | Network drop mid-download - observable failure | Medium |
| TC06 | Hidden iframe out of a11y tree | Medium |

## Usage
Pages will be available at: `https://esw1234.github.io/feature-testing/W-22247030-file-download-timeout/`

To use: open a test page, follow the steps, and log into the Service Console as `agent1@cwc.org / test1234` to send files from the agent side.